### PR TITLE
Update min node version to 18 in workflows and package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "*" # Ignore tags
 
 jobs:
-  build-node-16:
+  build-node-18:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Enable corepack
         run: corepack enable

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Bump min node js version requirement to 18. Builds on version 16 are failing unpredictably
https://github.com/sagentic-ai/sagentic-af/actions/runs/8721662955/job/23936712313