### PR TITLE
Gpt4 omni, dropped gpt3.5, pricing update

### DIFF
--- a/src/agents/one-shot.ts
+++ b/src/agents/one-shot.ts
@@ -26,6 +26,14 @@ export class OneShotAgent<
     return undefined;
   }
 
+  async inputAudio(): Promise<string | undefined> {
+    return undefined;
+  }
+
+  async inputVideo(): Promise<string | undefined> {
+    return undefined;
+  }
+
   async output(_answer: string): Promise<ResultType> {
     throw new Error("Method not implemented.");
   }
@@ -39,6 +47,20 @@ export class OneShotAgent<
         for (const image of images) {
           this.thread.appendUserImage(image);
         }
+      }
+    }
+
+    if (this.modelDetails?.supportsAudio) {
+      const audio = await this.inputAudio();
+      if (audio) {
+        this.thread.appendUserAudio(audio);
+      }
+    }
+
+    if (this.modelDetails?.supportsVideo) {
+      const video = await this.inputVideo();
+      if (video) {
+        this.thread.appendUserVideo(video);
       }
     }
   }

--- a/src/agents/reactive.ts
+++ b/src/agents/reactive.ts
@@ -118,14 +118,32 @@ export class ReactiveAgent<
 
   respond(
     message: string,
-    images?: string[],
-    options?: { detail: "auto" | "high" | "low" }
+    files?: {
+      images?: string[];
+      imageOptions?: { detail: "auto" | "high" | "low" };
+      videos?: string[];
+      videoOptions?: { detail: "auto" | "high" | "low" };
+      audios?: string[];
+      audioOptions?: { detail: "auto" | "high" | "low" }; //TODO placeholder until OpenAI supports audio
+    }
   ): void {
     this.abandon(this.thread);
     this.thread = this.thread.appendUserMessage(message);
-    if (images && this.modelDetails?.supportsImages) {
-      for (const image of images) {
-        this.thread = this.thread.appendUserImage(image, options);
+    if (files) {
+      if (files!.images && this.modelDetails?.supportsImages) {
+        for (const image of files!.images) {
+          this.thread = this.thread.appendUserImage(image, files!.imageOptions);
+        }
+      }
+      if (files!.videos && this.modelDetails?.supportsVideo) {
+        for (const video of files!.videos) {
+          this.thread = this.thread.appendUserVideo(video, files!.videoOptions);
+        }
+      }
+      if (files!.audios && this.modelDetails?.supportsAudio) {
+        for (const audio of files!.audios) {
+          this.thread = this.thread.appendUserAudio(audio, files!.audioOptions);
+        }
       }
     }
     this.adopt(this.thread);

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -116,8 +116,8 @@ export class Ledger extends EventEmitter {
     this.tokensPerModel[model].add(tokens);
 
     const cost: PCT = new PCT({
-      prompt: (tokens.prompt / 1000.0) * pricing[model].prompt,
-      completion: (tokens.completion / 1000.0) * pricing[model].completion,
+      prompt: (tokens.prompt / 1000000.0) * pricing[model].prompt,
+      completion: (tokens.completion / 1000000.0) * pricing[model].completion,
     });
 
     this.totalCost.add(cost);

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,7 +8,7 @@ export enum ModelType {
   GPT4Vision = "gpt-4-vision-preview",
   GPT4o = "gpt-4o",
 
-  GPT35Turbo = "gpt-3.5-turbo-1106",
+  GPT35Turbo = "gpt-3.5-turbo-0125",
 }
 
 /** Describes model pricing and limits */
@@ -66,8 +66,8 @@ export const pricing: Record<ModelType, ModelPricing> = {
     supportsAudio: false, //NB audio support is not yet in the API, TODO add this once OpenAI adds it
   },
   [ModelType.GPT35Turbo]: {
-    prompt: 1,
-    completion: 2,
+    prompt: 0.5,
+    completion: 1.5,
     contextSize: 16_385,
     rpm: 10_000,
     tpm: 1_000_000,

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,7 +8,6 @@ export enum ModelType {
   GPT4Vision = "gpt-4-vision-preview",
   GPT4o = "gpt-4o",
 
-  GPT35 = "gpt-3.5-turbo-16k",
   GPT35Turbo = "gpt-3.5-turbo-1106",
 }
 
@@ -65,13 +64,6 @@ export const pricing: Record<ModelType, ModelPricing> = {
     supportsImages: true,
     supportsVideo: true,
     supportsAudio: false, //NB audio support is not yet in the API, TODO add this once OpenAI adds it
-  },
-  [ModelType.GPT35]: {
-    prompt: 0.001,
-    completion: 0.002,
-    contextSize: 16_385,
-    rpm: 10_000,
-    tpm: 1_000_000,
   },
   [ModelType.GPT35Turbo]: {
     prompt: 0.001,

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,6 +6,7 @@ export enum ModelType {
   GPT4 = "gpt-4",
   GPT4Turbo = "gpt-4-turbo-preview",
   GPT4Vision = "gpt-4-vision-preview",
+  GPT4o = "gpt-4o",
 
   GPT35 = "gpt-3.5-turbo-16k",
   GPT35Turbo = "gpt-3.5-turbo-1106",
@@ -25,6 +26,10 @@ export interface ModelPricing {
   tpm: number;
   /** does it support images? */
   supportsImages?: boolean;
+  /** does it support video? */
+  supportsVideo?: boolean;
+  /** does it support audio? */
+  supportsAudio?: boolean;
 }
 
 /** Pricing and limits for each model */
@@ -50,6 +55,16 @@ export const pricing: Record<ModelType, ModelPricing> = {
     rpm: 80,
     tpm: 10_000,
     supportsImages: true,
+  },
+  [ModelType.GPT4o]: {
+    prompt: 0.01,
+    completion: 0.03,
+    contextSize: 128_000,
+    rpm: 500,
+    tpm: 30_000,
+    supportsImages: true,
+    supportsVideo: true,
+    supportsAudio: false, //NB audio support is not yet in the API, TODO add this once OpenAI adds it
   },
   [ModelType.GPT35]: {
     prompt: 0.001,

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,9 +13,9 @@ export enum ModelType {
 
 /** Describes model pricing and limits */
 export interface ModelPricing {
-  /** price per prompt token in USD */
+  /** price per 1M prompt tokens in USD */
   prompt: number;
-  /** price per completion token in USD */
+  /** price per 1M completion tokens in USD */
   completion: number;
   /** context size in tokens */
   contextSize: number;
@@ -34,30 +34,30 @@ export interface ModelPricing {
 /** Pricing and limits for each model */
 export const pricing: Record<ModelType, ModelPricing> = {
   [ModelType.GPT4]: {
-    prompt: 0.03,
-    completion: 0.06,
+    prompt: 30,
+    completion: 60,
     contextSize: 8_192,
     rpm: 10_000,
     tpm: 300_000,
   },
   [ModelType.GPT4Turbo]: {
-    prompt: 0.01,
-    completion: 0.03,
+    prompt: 10,
+    completion: 30,
     contextSize: 128_000,
     rpm: 5000,
     tpm: 300_000,
   },
   [ModelType.GPT4Vision]: {
-    prompt: 0.01,
-    completion: 0.03,
+    prompt: 10,
+    completion: 30,
     contextSize: 128_000,
     rpm: 80,
     tpm: 10_000,
     supportsImages: true,
   },
   [ModelType.GPT4o]: {
-    prompt: 0.01,
-    completion: 0.03,
+    prompt: 5,
+    completion: 15,
     contextSize: 128_000,
     rpm: 500,
     tpm: 30_000,
@@ -66,8 +66,8 @@ export const pricing: Record<ModelType, ModelPricing> = {
     supportsAudio: false, //NB audio support is not yet in the API, TODO add this once OpenAI adds it
   },
   [ModelType.GPT35Turbo]: {
-    prompt: 0.001,
-    completion: 0.002,
+    prompt: 1,
+    completion: 2,
     contextSize: 16_385,
     rpm: 10_000,
     tpm: 1_000_000,

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -402,6 +402,45 @@ export class Thread implements Identified, Conclusible, ChildOf<Agent> {
     }
   }
 
+  /** Append a video to this thread.
+   * Beware: this method mutates the thread when it's incomplete. Always use the return value.
+   * It is only legal to append video if the thread is not complete.
+   * @throws Error if the thread is complete
+   * @param message Message to append
+   * @param images Images to append
+   * @returns new Thread object with the image appended
+   */
+  appendUserVideo(
+    //TODO finalize this
+    video: any,
+    options?: any
+  ): Thread {
+    if (!this.parent.modelDetails?.supportsVideo) {
+      throw new Error("This agent does not support images");
+    }
+    //TODO implement this; need to process video into frames and append them as images
+    //audio needs to be extracted and appended as well
+    throw new Error("Video is not supported yet");
+  }
+
+  /** Append an audio file to this thread.
+   * Beware: this method mutates the thread when it's incomplete. Always use the return value.
+   * It is only legal to append image if the thread is not complete.
+   * @throws Error if the thread is complete
+   * @returns new Thread object with the audio appended
+   */
+  appendUserAudio(
+    //TODO finalize this
+    audio: any,
+    options?: any
+  ): Thread {
+    if (!this.parent.modelDetails?.supportsAudio) {
+      throw new Error("This agent does not support audio");
+    }
+    //TODO add this once OpenAI supports audio
+    throw new Error("Audio is not supported yet");
+  }
+
   /** Append a tool result to this thread.
    * Beware: this method mutates the thread when it's incomplete. Always use the return value.
    * It is only legal if the thread is complete and the last message in the thread is a tool call.

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -32,7 +32,7 @@ describe("Client", () => {
       }
     );
     await api.init();
-    client = new Client(APIKEY, ModelType.GPT35, {
+    client = new Client(APIKEY, ModelType.GPT35Turbo, {
       baseURL: BASEPATH,
       fetch: api.fetch.bind(api),
     });
@@ -50,7 +50,7 @@ describe("Client", () => {
 
   test("Simple Request", async () => {
     const response = await client.createChatCompletion({
-      model: ModelType.GPT35,
+      model: ModelType.GPT35Turbo,
       messages: [
         { role: "system", content: "You answer with 'Foo' to all prompts." },
         { role: "user", content: "Hello" },
@@ -67,7 +67,7 @@ describe("Client", () => {
     for (let i = 0; i < n; i++) {
       promises.push(
         client.createChatCompletion({
-          model: ModelType.GPT35,
+          model: ModelType.GPT35Turbo,
           messages: [
             {
               role: "system",
@@ -92,7 +92,7 @@ describe("Client", () => {
       errorProbability: 1,
     });
     client.stop();
-    client = new Client(APIKEY, ModelType.GPT35, {
+    client = new Client(APIKEY, ModelType.GPT35Turbo, {
       baseURL: BASEPATH,
       fetch: api.fetch.bind(api),
       maxRetries: 0,
@@ -101,7 +101,7 @@ describe("Client", () => {
     client.start();
     try {
       const _response = await client.createChatCompletion({
-        model: ModelType.GPT35,
+        model: ModelType.GPT35Turbo,
         messages: [
           { role: "system", content: "You answer with 'Foo' to all prompts." },
           { role: "user", content: "Hello" },
@@ -126,7 +126,7 @@ describe("Client", () => {
     });
     try {
       const _response = await client.createChatCompletion({
-        model: ModelType.GPT35,
+        model: ModelType.GPT35Turbo,
         messages: [
           { role: "system", content: "You answer with 'Foo' to all prompts." },
           { role: "user", content: "Hello" },
@@ -155,7 +155,7 @@ describe("Client", () => {
 
     // first request should be fine
     const response1 = await client.createChatCompletion({
-      model: ModelType.GPT35,
+      model: ModelType.GPT35Turbo,
       messages: [
         { role: "system", content: "You answer with 'Foo' to all prompts." },
         { role: "user", content: "Hello" },
@@ -167,7 +167,7 @@ describe("Client", () => {
 
     // 2nd test should take 10 seconds to complete due to rate limit and retries
     const response2 = await client.createChatCompletion({
-      model: ModelType.GPT35,
+      model: ModelType.GPT35Turbo,
       messages: [
         { role: "system", content: "You answer with 'Foo' to all prompts." },
         { role: "user", content: "Hello" },
@@ -190,7 +190,7 @@ describe("Client", () => {
       },
     });
     const response = await client.createChatCompletion({
-      model: ModelType.GPT35,
+      model: ModelType.GPT35Turbo,
       messages: [{ role: "system", content: "foo" }],
     });
     expect(response).toBeDefined();

--- a/test/ledger.test.ts
+++ b/test/ledger.test.ts
@@ -73,7 +73,7 @@ describe("Ledger", () => {
 
     ledger.add(
       "test",
-      ModelType.GPT35,
+      ModelType.GPT35Turbo,
       timing,
       new PCT({ prompt: a, completion: b })
     );
@@ -82,15 +82,15 @@ describe("Ledger", () => {
     expectPCT(ledger.tokens, a, b);
     expectPCT(
       ledger.cost,
-      pricing[ModelType.GPT35].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35].completion * (b / 1000.0)
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
     );
 
-    expectPCT(ledger.modelTokens[ModelType.GPT35], a, b);
+    expectPCT(ledger.modelTokens[ModelType.GPT35Turbo], a, b);
     expectPCT(
-      ledger.modelCost[ModelType.GPT35],
-      pricing[ModelType.GPT35].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35].completion * (b / 1000.0)
+      ledger.modelCost[ModelType.GPT35Turbo],
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
     );
   });
 
@@ -110,16 +110,16 @@ describe("Ledger", () => {
     expectPCT(ledger.tokens, 2 * a, 2 * b);
     expectPCT(
       ledger.cost,
-      (pricing[ModelType.GPT35].prompt * a) / 1000.0 +
+      (pricing[ModelType.GPT35Turbo].prompt * a) / 1000.0 +
         (pricing[ModelType.GPT4].prompt * a) / 1000.0,
-      (pricing[ModelType.GPT35].completion * b) / 1000.0 +
+      (pricing[ModelType.GPT35Turbo].completion * b) / 1000.0 +
         (pricing[ModelType.GPT4].completion * b) / 1000.0
     );
-    expectPCT(ledger.modelTokens[ModelType.GPT35], a, b);
+    expectPCT(ledger.modelTokens[ModelType.GPT35Turbo], a, b);
     expectPCT(
-      ledger.modelCost[ModelType.GPT35],
-      pricing[ModelType.GPT35].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35].completion * (b / 1000.0)
+      ledger.modelCost[ModelType.GPT35Turbo],
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
     );
     expectPCT(ledger.modelTokens[ModelType.GPT4], a, b);
     expectPCT(

--- a/test/ledger.test.ts
+++ b/test/ledger.test.ts
@@ -9,7 +9,7 @@ import { meta, Timing, delay } from "../src/common";
 const expectPCT = (pct: PCT, prompt: number, completion: number) => {
   expect(pct.prompt).toBe(prompt);
   expect(pct.completion).toBe(completion);
-  expect(pct.total).toBe(prompt + completion);
+  expect(pct.total).toBeCloseTo(prompt + completion);
 };
 
 const mockSession = () => {
@@ -82,15 +82,15 @@ describe("Ledger", () => {
     expectPCT(ledger.tokens, a, b);
     expectPCT(
       ledger.cost,
-      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000000.0)
     );
 
     expectPCT(ledger.modelTokens[ModelType.GPT35Turbo], a, b);
     expectPCT(
       ledger.modelCost[ModelType.GPT35Turbo],
-      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000000.0)
     );
   });
 
@@ -110,22 +110,22 @@ describe("Ledger", () => {
     expectPCT(ledger.tokens, 2 * a, 2 * b);
     expectPCT(
       ledger.cost,
-      (pricing[ModelType.GPT35Turbo].prompt * a) / 1000.0 +
-        (pricing[ModelType.GPT4].prompt * a) / 1000.0,
-      (pricing[ModelType.GPT35Turbo].completion * b) / 1000.0 +
-        (pricing[ModelType.GPT4].completion * b) / 1000.0
+      (pricing[ModelType.GPT35Turbo].prompt * a) / 1000000.0 +
+        (pricing[ModelType.GPT4].prompt * a) / 1000000.0,
+      (pricing[ModelType.GPT35Turbo].completion * b) / 1000000.0 +
+        (pricing[ModelType.GPT4].completion * b) / 1000000.0
     );
     expectPCT(ledger.modelTokens[ModelType.GPT35Turbo], a, b);
     expectPCT(
       ledger.modelCost[ModelType.GPT35Turbo],
-      pricing[ModelType.GPT35Turbo].prompt * (a / 1000.0),
-      pricing[ModelType.GPT35Turbo].completion * (b / 1000.0)
+      pricing[ModelType.GPT35Turbo].prompt * (a / 1000000.0),
+      pricing[ModelType.GPT35Turbo].completion * (b / 1000000.0)
     );
     expectPCT(ledger.modelTokens[ModelType.GPT4], a, b);
     expectPCT(
       ledger.modelCost[ModelType.GPT4],
-      pricing[ModelType.GPT4].prompt * (a / 1000.0),
-      pricing[ModelType.GPT4].completion * (b / 1000.0)
+      pricing[ModelType.GPT4].prompt * (a / 1000000.0),
+      pricing[ModelType.GPT4].completion * (b / 1000000.0)
     );
 
     expectPCT(


### PR DESCRIPTION
- added GPT4o model
- added stubs for video/audio support for future implementation
- dropped non-turbo version of GPT3.5
- updated GPT3.5Turbo to the latest available version
- updated pricing on models
- changed pricing in model card to be per 1M tokens for better readability