### PR TITLE
Allow registering custom clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagentic-ai/sagentic-af",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Sagentic.ai Agent Framework",
   "homepage": "https://sagentic.ai",
   "repository": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -60,7 +60,7 @@ export interface AgentEvents<StateType, ResultType> {
 export interface BaseAgent<
   OptionsType extends AgentOptions,
   StateType,
-  ResultType
+  ResultType,
 > {
   on<U extends keyof AgentEvents<StateType, ResultType>>(
     event: U,

--- a/src/agents/one-shot.ts
+++ b/src/agents/one-shot.ts
@@ -8,7 +8,7 @@ import { Thread } from "../thread";
 
 export class OneShotAgent<
   OptionsType extends AgentOptions,
-  ResultType
+  ResultType,
 > extends BaseAgent<OptionsType, void, ResultType> {
   model: BuiltinModel | ModelMetadata = BuiltinModel.GPT35Turbo;
   thread: Thread;

--- a/src/client_mux.ts
+++ b/src/client_mux.ts
@@ -7,6 +7,7 @@ import {
   ModelMetadata,
   BuiltinProvider,
   ClientType,
+  BuiltinClientType,
   models as availableModels,
 } from "./models";
 import {
@@ -21,12 +22,28 @@ import { AnthropicClient } from "./clients/anthropic";
 
 import log from "loglevel";
 
-const clientConstructors = {
-  [ClientType.OpenAI]: OpenAIClient,
-  [ClientType.AzureOpenAI]: AzureOpenAIClient,
-  [ClientType.Google]: GoogleClient,
-  [ClientType.Anthropic]: AnthropicClient,
+const builtinConstructors = {
+  [BuiltinClientType.OpenAI]: OpenAIClient,
+  [BuiltinClientType.AzureOpenAI]: AzureOpenAIClient,
+  [BuiltinClientType.Google]: GoogleClient,
+  [BuiltinClientType.Anthropic]: AnthropicClient,
 };
+
+let clientConstructors: Record<
+  ClientType,
+  new (key: string, model: ModelMetadata, options?: ClientOptions) => Client
+> = { ...builtinConstructors };
+
+export function registerClientType(
+  clientType: ClientType,
+  constructor: new (
+    key: string,
+    model: ModelMetadata,
+    options?: ClientOptions
+  ) => Client
+): void {
+  clientConstructors[clientType] = constructor;
+}
 
 interface ClientMuxOptions {
   models?: ModelMetadata[];

--- a/src/clients/base.ts
+++ b/src/clients/base.ts
@@ -37,7 +37,7 @@ interface Ticket<RequestType, ResponseType> {
 export abstract class BaseClient<
   RequestType,
   ResponseType,
-  OptionsType extends BaseClientOptions
+  OptionsType extends BaseClientOptions,
 > implements Client
 {
   /** Model to use */

--- a/src/clients/common.ts
+++ b/src/clients/common.ts
@@ -2,9 +2,16 @@ import { ModelID } from "../models";
 import { Message } from "../thread";
 import { ClientOptions as OpenAIClientOptionsBase } from "openai";
 
-import { get_encoding } from "tiktoken";
+let isVscode: boolean = false;
+let encoding: any;
 
-const encoding = get_encoding("cl100k_base");
+// check if we have tiktoken
+try {
+  require.resolve("vscode");
+  isVscode = true;
+} catch (e) {
+  isVscode = false;
+}
 
 /**
  * Count the number of tokens in a given text.
@@ -12,6 +19,16 @@ const encoding = get_encoding("cl100k_base");
  * @returns The number of tokens in the text.
  */
 export const countTokens = (text: string): number => {
+  // check if we have tiktoken encoding available
+  if (isVscode) {
+    throw new Error("This function is not supported in VSCode");
+  }
+
+  if (!encoding) {
+    const { get_encoding } = require("tiktoken");
+    encoding = get_encoding("cl100k_base");
+  }
+
   return encoding.encode(text).length;
 };
 

--- a/src/clients/openai.ts
+++ b/src/clients/openai.ts
@@ -39,7 +39,7 @@ const estimateTokens = (
 
 /** OpenAI Client wrapper */
 export abstract class OpenAIClientBase<
-  Options extends ClientOptions
+  Options extends ClientOptions,
 > extends BaseClient<
   OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
   OpenAI.Chat.Completions.ChatCompletion,
@@ -246,35 +246,38 @@ export const parseDuration = (duration: string): moment.Duration => {
     log.warn("WARNING: no parts when parsing time in client:", duration);
     return moment.duration(0);
   }
-  const units: Record<string, number> = parts.reduce((acc, part) => {
-    const s = part.match(/(\d{1,5})(h|ms|m|s)/);
-    if (s === null) {
-      log.warn("WARNING: invalid part format:", part);
+  const units: Record<string, number> = parts.reduce(
+    (acc, part) => {
+      const s = part.match(/(\d{1,5})(h|ms|m|s)/);
+      if (s === null) {
+        log.warn("WARNING: invalid part format:", part);
+        return acc;
+      }
+
+      const num = parseInt(s[1], 10);
+
+      if (isNaN(num)) {
+        log.warn("WARNING: NaN when parsing time in client", s[1], s[2]);
+        return acc;
+      }
+
+      const unit = {
+        s: "seconds",
+        m: "minutes",
+        h: "hours",
+        ms: "milliseconds",
+      }[s[2]];
+
+      if (!unit) {
+        log.warn("WARNING: unknown unit when parsing time in client", s[2]);
+        return acc;
+      }
+
+      acc[unit] = num;
       return acc;
-    }
-
-    const num = parseInt(s[1], 10);
-
-    if (isNaN(num)) {
-      log.warn("WARNING: NaN when parsing time in client", s[1], s[2]);
-      return acc;
-    }
-
-    const unit = {
-      s: "seconds",
-      m: "minutes",
-      h: "hours",
-      ms: "milliseconds",
-    }[s[2]];
-
-    if (!unit) {
-      log.warn("WARNING: unknown unit when parsing time in client", s[2]);
-      return acc;
-    }
-
-    acc[unit] = num;
-    return acc;
-  }, {} as Record<string, number>);
+    },
+    {} as Record<string, number>
+  );
   return moment.duration(units);
 };
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -15,12 +15,15 @@ export import Provider = BuiltinProvider;
 export type ProviderID = BuiltinProvider | string;
 
 /** Available client types */
-export enum ClientType {
+export enum BuiltinClientType {
   OpenAI = "openai",
   AzureOpenAI = "azure-openai",
   Google = "google",
   Anthropic = "anthropic",
 }
+
+/** Identifier for client type */
+export type ClientType = BuiltinClientType | string;
 
 /** default endpoints for each provider */
 /* N.B. For most clients the api endpoint is simply an URL string, but Azure OpenAI API
@@ -46,22 +49,22 @@ export const providers: Record<ProviderID, ProviderMetadata> = {
   [BuiltinProvider.OpenAI]: {
     id: BuiltinProvider.OpenAI,
     url: endpoints[BuiltinProvider.OpenAI],
-    clientType: ClientType.OpenAI,
+    clientType: BuiltinClientType.OpenAI,
   },
   [BuiltinProvider.AzureOpenAI]: {
     id: BuiltinProvider.AzureOpenAI,
     url: endpoints[BuiltinProvider.AzureOpenAI],
-    clientType: ClientType.AzureOpenAI,
+    clientType: BuiltinClientType.AzureOpenAI,
   },
   [BuiltinProvider.Google]: {
     id: BuiltinProvider.Google,
     url: endpoints[BuiltinProvider.Google],
-    clientType: ClientType.Google,
+    clientType: BuiltinClientType.Google,
   },
   [BuiltinProvider.Anthropic]: {
     id: BuiltinProvider.Anthropic,
     url: endpoints[BuiltinProvider.Anthropic],
-    clientType: ClientType.Anthropic,
+    clientType: BuiltinClientType.Anthropic,
   },
 };
 

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -206,7 +206,7 @@ export function tool(
       ? N extends string
         ? N
         : never
-      : never
+      : never,
   >(
     target: (this: This, ...args: Args) => Return,
     context: ClassMethodDecoratorContext<


### PR DESCRIPTION
Users can now use `registerClientType` function to register their own clients for use with sagentic.