### PR TITLE
LLM call events, fix windows dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagentic-ai/sagentic-af",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Sagentic.ai Agent Framework",
   "homepage": "https://sagentic.ai",
   "repository": {


### PR DESCRIPTION
Added `llm-request` and `llm-response` events to base `Agent`, which are emitted when it makes calls and receives responses from the model API.

Fixed import paths in the dev server on Windows.