### PR TITLE
add tool choice, fix agent stop in tool handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagentic-ai/sagentic-af",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Sagentic.ai Agent Framework",
   "homepage": "https://sagentic.ai",
   "repository": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -20,7 +20,7 @@ import {
   ModelCard,
 } from "./models";
 import { Session } from "./session";
-import { ModelInvocationOptions } from "./clients/common";
+import { ModelInvocationOptions, ToolChoice, ToolMode } from "./clients/common";
 import { Message, Thread, ToolAssistantContent, ToolCall } from "./thread";
 import { Tool, ToolSpec, SupportingTool } from "./tool";
 import { EventEmitter } from "events";
@@ -35,6 +35,8 @@ export interface AgentOptions {
   topic?: string;
   /** Tools for the agent to use */
   tools?: Tool[];
+  /** Tool choice mode for the agent */ 
+  tool_choice?: ToolMode | ToolChoice;
   /** System prompt for the agent */
   systemPrompt?: string;
   /** Eat tool results */
@@ -125,6 +127,9 @@ export class BaseAgent<OptionsType extends AgentOptions, StateType, ResultType>
 
   /** Tools for the agent to use */
   tools: Tool[] = [];
+
+  /** Tool mode for the agent to use. */
+  tool_choice?: ToolMode | ToolChoice;
 
   /** Flag to indicate whether the tool results should be removed from threads after they were read */
   eatToolResults: boolean = false;
@@ -368,6 +373,9 @@ export class BaseAgent<OptionsType extends AgentOptions, StateType, ResultType>
     };
     if (this.tools.length > 0) {
       options.tools = this.describeTools();
+    }
+    if (this.tool_choice) {
+      options.tool_choice = this.tool_choice;
     }
     if (this.expectsJSON) {
       options.response_format = { type: "json_object" };

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -321,6 +321,16 @@ export class BaseAgent<OptionsType extends AgentOptions, StateType, ResultType>
       }
       this.abandon(nextThread);
       this.adopt(nextThread2);
+
+      // agent might've been stopped in the tool handler, 
+      // so we need to check if it is still active
+      if (!this.isActive) {
+        // we need to append dummy assistant response to complete the thread
+        return nextThread2.appendAssistantMessage(
+          "Agent has been stopped, no further responses will be generated."
+        );
+      }
+
       // finally we need to invoke the model again to pass the tool responses to the assistant
       // and obtain its response
       const assistantRespondedThread = await this.advance(nextThread2);

--- a/src/clients/anthropic.ts
+++ b/src/clients/anthropic.ts
@@ -5,6 +5,7 @@ import {
   ChatCompletionRequest,
   ChatCompletionResponse,
   countTokens,
+  ToolMode,
 } from "./common";
 import { BaseClient, RejectionReason } from "./base";
 import { Message, MessageRole, ContentPart, TextContentPart } from "../thread";
@@ -162,6 +163,26 @@ export class AnthropicClient extends BaseClient<
         } as Anthropic.Beta.Tools.Tool;
       }),
     } as Anthropic.Beta.Tools.MessageCreateParams;
+
+    if (request.options?.tool_choice) {
+      switch (request.options.tool_choice) {
+        case ToolMode.AUTO:
+          apiRequest.tool_choice = { type: "auto" };
+          break;
+        case ToolMode.NONE:
+          delete apiRequest.tools; // No tools
+          break;
+        case ToolMode.REQUIRED:
+          apiRequest.tool_choice = { type: "any" };
+          break;
+        default: // ToolChoice
+          apiRequest.tool_choice = {
+            type: "tool",
+            name: request.options.tool_choice.function.name,
+          };
+          break;
+      }
+    }
 
     let response: Anthropic.Beta.Tools.ToolsBetaMessage;
     if (this.model.card.supportsImages) {

--- a/src/clients/common.ts
+++ b/src/clients/common.ts
@@ -32,11 +32,25 @@ export const countTokens = (text: string): number => {
   return encoding.encode(text).length;
 };
 
+export enum ToolMode {
+  AUTO = "auto",
+  NONE = "none",
+  REQUIRED = "required",
+}
+
+export interface ToolChoice {
+  type: "function";
+  function: {
+    name: string;
+  }
+}
+
 /**
  * Model invocation options
  */
 export type ModelInvocationOptions = {
   tools?: any; //TODO: define tools
+  tool_choice?: ToolMode | ToolChoice;
   response_format?: any; //TODO: define response_format
   temperature: number;
   max_tokens?: number;

--- a/src/clients/google.ts
+++ b/src/clients/google.ts
@@ -8,7 +8,8 @@ import {
   TextPart,
   FunctionCallPart,
   FunctionResponsePart,
-  FunctionCallingMode,
+  FunctionCallingMode as Mode,
+  FunctionCallingConfig,
 } from "@google/generative-ai";
 import { ModelMetadata, BuiltinModel } from "../models";
 import {
@@ -16,6 +17,7 @@ import {
   GoogleClientOptions,
   ChatCompletionRequest,
   ChatCompletionResponse,
+  ToolMode,
 } from "./common";
 import { BaseClient, RejectionReason } from "./base";
 import { Message, MessageRole, ContentPart, TextContentPart } from "../thread";
@@ -172,6 +174,34 @@ export class GoogleClient extends BaseClient<
           functionDeclarations: tools,
         },
       ];
+      if (request.options?.tool_choice) {
+        let functionCallingConfig: FunctionCallingConfig;
+        switch (request.options.tool_choice) {
+          case ToolMode.AUTO:
+            functionCallingConfig = {
+              mode: Mode.AUTO,
+            };
+            break;
+          case ToolMode.NONE:
+            functionCallingConfig = {
+              mode: Mode.NONE,
+            };
+            break;
+          case ToolMode.REQUIRED:
+            functionCallingConfig = {
+              mode: Mode.ANY,
+            };
+            break;
+          default: // ToolChoice
+            functionCallingConfig = {
+              mode: Mode.ANY,
+              allowedFunctionNames: [ request.options.tool_choice.function.name ],
+            };
+          }
+        googleRequest.toolConfig = {
+          functionCallingConfig: functionCallingConfig,
+        };
+      } 
     }
 
     // const tokens = estimateTokens(googleRequest);

--- a/src/clients/openai.ts
+++ b/src/clients/openai.ts
@@ -166,6 +166,7 @@ export abstract class OpenAIClientBase<
       temperature: request.options?.temperature,
       max_tokens: request.options?.max_tokens,
       tools: request.options?.tools,
+      tool_choice: request.options?.tool_choice,
       response_format: request.options?.response_format,
       messages: request.messages as OpenAI.Chat.ChatCompletionMessageParam[],
     };


### PR DESCRIPTION
Added support for `tool_choice` option:

    Agents can specify `tool_choice` option to control how the model
    responds. With `auto`, it chooses by itself whether to make a tool call
    and which tool to call. With `none`, it won't call any tools. With
    `required`, it will always make a tool call instead of a normal
    response. It's also possible to specify a concrete tool that the model
    must call.

Fix agent stop in tool handler:

    Calling `stop()` in a tool handler would not actually stop the agent
    until the next time the model made a regular (i.e. non-tool-call)
    response. Made the tool call handling routine exit early if it detects
    that the agent was stopped in a tool call handler.