### PR TITLE
alternative duration parse in retry headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagentic-ai/sagentic-af",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Sagentic.ai Agent Framework",
   "homepage": "https://sagentic.ai",
   "repository": {

--- a/src/clients/openai.ts
+++ b/src/clients/openai.ts
@@ -245,6 +245,12 @@ export const parseDuration = (duration: string): moment.Duration => {
   const parts = duration.match(/(\d{1,5}(h|ms|m|s))/g);
   if (parts === null) {
     log.warn("WARNING: no parts when parsing time in client:", duration);
+    // the duration might also be just a number of seconds, try to parse that
+    const num = parseInt(duration, 10);
+    if (!isNaN(num)) {
+      return moment.duration(num, "seconds");
+    }
+    log.warn("WARNING: unknown duration format:", duration);
     return moment.duration(0);
   }
   const units: Record<string, number> = parts.reduce(


### PR DESCRIPTION
Some APIs (e.g. Azure OpenAI) seem to have the retry headers in a different time format - presumably just a number of seconds to wait before retrying. Added fallback parser for that case.