### PR TITLE
Fix budget handler multiple calls in parallel scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sagentic-ai/sagentic-af",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Sagentic.ai Agent Framework",
   "homepage": "https://sagentic.ai",
   "repository": {


### PR DESCRIPTION
## Fix budget handler multiple calls in parallel scenarios

This PR fixes a bug where the session budget handler could be called multiple times when parallel operations hit the budget limit simultaneously, leading to multiple user prompts.

### Changes Made

**Fixed the core issue in `checkBudgetAndHandle`:** When multiple operations are waiting for a budget handler to complete, they now fail immediately with "Session budget exceeded" if the budget is still exceeded after waiting, instead of calling the handler again.

**Enhanced documentation:** Updated the `SessionBudgetHandler` type documentation to clearly explain the behavior in concurrent scenarios, including that waiting operations check budget individually and may have different outcomes based on timing.

### Impact

This ensures that users only see one budget prompt even when multiple parallel agents hit the budget limit simultaneously. Previously, if a user declined to increase the budget, they would see multiple prompts as each waiting operation tried to call the budget handler again.

The fix maintains backward compatibility while providing more predictable behavior for the generic framework.